### PR TITLE
Fix double-load warning by changing load to require

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    roleback (0.2.0)
+    roleback (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/roleback.rb
+++ b/lib/roleback.rb
@@ -1,6 +1,7 @@
 require "roleback/version"
 require 'roleback/definitions/load'
-Dir["#{File.dirname(__FILE__)}/roleback/**/*.rb"].each { |f| load(f) }
+# use require instead of load to avoid re-executing already-loaded files
+Dir["#{File.dirname(__FILE__)}/roleback/**/*.rb"].each { |f| require(f) }
 
 module Roleback
 	class Error < StandardError; end

--- a/lib/roleback/version.rb
+++ b/lib/roleback/version.rb
@@ -1,3 +1,3 @@
 module Roleback
-	VERSION = "0.2.0".freeze
+	VERSION = "0.2.1".freeze
 end


### PR DESCRIPTION
## Summary
- `lib/roleback.rb` used `load()` to glob all `.rb` files, which re-executed `version.rb` that was already loaded via `require`. This produces `warning: already initialized constant Roleback::VERSION` on Ruby 4.0+.
- Changed `load(f)` to `require(f)` so already-loaded files are skipped.
- Bumped version to 0.2.1.

## Test plan
- [x] All 55 rspec examples pass